### PR TITLE
feat: Tela aluno: ver trilha por matéria com indicadores (concluído, disponível, bloqueado, recomendado)

### DIFF
--- a/src/pages/dashboard-student.tsx
+++ b/src/pages/dashboard-student.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useMemo } from 'react'
+import { useNavigate } from 'react-router-dom'
 import { useAuth } from '../hooks/useAuth'
 import {
   BookOpen,
@@ -11,9 +12,11 @@ import {
 import { SUMMARY_CONFIG } from '../constant/summary'
 import { DashboardStudent as DashboardType } from '../components/ui/dashboard' // Sua interface postada
 import { getByUser } from '../resources/dashboardResources'
+import { Routes } from '../router/constants/routesMap'
 
 const DashboardStudent = () => {
   const { user } = useAuth()
+  const navigate = useNavigate()
   const [studentDashboard, setStudentDashboard] = useState<DashboardType | null>(null)
   const [loading, setLoading] = useState(true)
 
@@ -145,7 +148,11 @@ const DashboardStudent = () => {
             )}
           </div>
           <footer className="flex mt-auto pt-6 border-t border-gray-100 justify-center">
-            <button className="flex items-center gap-1 text-sm text-gray-700 hover:text-blue-700 hover:font-bold transition-all">
+            <button
+              type="button"
+              onClick={() => navigate(Routes.STUDENT_TRIALS)}
+              className="flex items-center gap-1 text-sm text-gray-700 hover:text-blue-700 hover:font-bold transition-all"
+            >
               <span>Ver todas as trilhas</span>
               <CaretRightIcon size={16} />
             </button>

--- a/src/pages/student-trails.tsx
+++ b/src/pages/student-trails.tsx
@@ -1,15 +1,17 @@
-import { Play, CheckCircle, Lock } from '@phosphor-icons/react'
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { BookOpen, CheckCircle, Lock, Play } from '@phosphor-icons/react'
 import { useEffect, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 
+import { subjects } from '@/constant/category'
 import { useAuth } from '@/hooks/useAuth'
-import { getForStudent, LearningPath } from '@/resources/learningPathResources'
+import {
+  getForStudent,
+  LearningPath,
+  LearningPathContentStatus,
+} from '@/resources/learningPathResources'
 import { Routes } from '@/router/constants/routesMap'
-
-interface Category {
-  id: string
-  name: string
-}
+import { contentService, type CategoryDto } from '@/services/contentService'
 
 const StudentTrailsPage = () => {
   const navigate = useNavigate()
@@ -17,15 +19,8 @@ const StudentTrailsPage = () => {
 
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
+  const [categories, setCategories] = useState<CategoryDto[]>([])
   const [learningPaths, setLearningPaths] = useState<LearningPath[]>([])
-
-  const categories: Category[] = [
-    { name: 'Português', id: '5677af84-cccc-476f-ab5e-e4789e18ee85' },
-    { name: 'Matemática', id: '8db6ca2e-0da4-4ac4-ba2e-0adfb7f01275' },
-    { name: 'Ciências', id: '7f2a1f19-d1aa-4bad-89e5-fc7d22c66bf2' },
-    { name: 'História', id: '46c7096e-8c05-4d2a-8cb2-2fa6ff88f187' },
-    { name: 'Geografia', id: 'c32e3cf1-32aa-4830-9662-3c3718d5a251' },
-  ]
 
   useEffect(() => {
     if (!isLoggedIn) {
@@ -38,42 +33,67 @@ const StudentTrailsPage = () => {
       return
     }
 
-    if (me?.sub) {
-      fetchLearningPaths(categories)
-    }
-  }, [isLoggedIn, me])
+    const fetchAll = async () => {
+      setLoading(true)
+      setError(null)
 
-  const fetchLearningPaths = async (categories: { id: string; name: string }[]) => {
-    setLoading(true)
-    setError(null)
+      try {
+        // 1) Busca as categorias reais do backend
+        const apiCategories = await contentService.getCategories()
+        setCategories(apiCategories)
 
-    try {
-      const allLearningPaths: LearningPath[] = []
+        const all: LearningPath[] = []
 
-      for (const category of categories) {
-        try {
-          const response = await getForStudent(category.id)
+        // 2) Para cada matéria conhecida (Português, Matemática, ...) procura a categoria correspondente
+        //    e busca a trilha padrão para aquela matéria/série do aluno.
+        for (const subjectName of subjects) {
+          const category = apiCategories.find((c) => c.name === subjectName)
+          if (!category) continue
 
-          const paths: LearningPath[] = response.data ? [response.data] : []
-          allLearningPaths.push(...paths)
-        } catch (err) {
-          console.error(`Erro ao carregar trilhas da categoria ${category.name}`, err)
+          try {
+            const response = await getForStudent(category.id)
+            const data = response.data as
+              | LearningPath
+              | LearningPath[]
+              | { learningPaths: LearningPath[] }
+
+            let path: LearningPath | null = null
+
+            if (Array.isArray(data)) {
+              path = data[0] ?? null
+            } else if (data && 'learningPaths' in data && Array.isArray(data.learningPaths)) {
+              path = data.learningPaths[0] ?? null
+            } else {
+              path = data as LearningPath
+            }
+
+            if (path) {
+              all.push(path)
+            }
+          } catch (err: any) {
+            // 404 significa que não há trilha definida para aquela matéria/série.
+            if (err?.response?.status !== 404) {
+              // Para outros erros, apenas registra no console e segue com as demais matérias.
+              // A mensagem geral será exibida abaixo se nenhuma trilha for carregada.
+
+              console.error('Erro ao carregar trilha da categoria', category.name, err)
+            }
+          }
         }
+
+        setLearningPaths(all)
+      } catch {
+        setError('Não foi possível carregar suas trilhas de aprendizado.')
+        setLearningPaths([])
+      } finally {
+        setLoading(false)
       }
-
-      const uniquePaths = Array.from(
-        new Map(allLearningPaths.map((item) => [item.id, item])).values()
-      )
-      setLearningPaths(uniquePaths)
-    } catch (err) {
-      setError('Não foi possível carregar suas trilhas de aprendizado.' + err)
-      setLearningPaths([])
-    } finally {
-      setLoading(false)
     }
-  }
 
-  const getStatusStyle = (status: string) => {
+    fetchAll()
+  }, [isLoggedIn, me, navigate])
+
+  const getStatusStyle = (status: LearningPathContentStatus) => {
     switch (status) {
       case 'completed':
         return 'bg-green-100 border-green-300 text-green-700'
@@ -86,7 +106,7 @@ const StudentTrailsPage = () => {
     }
   }
 
-  const getStatusName = (status: string) => {
+  const getStatusName = (status: LearningPathContentStatus) => {
     switch (status) {
       case 'available':
         return 'Disponível'
@@ -108,9 +128,11 @@ const StudentTrailsPage = () => {
         <h2 className="text-slate-500">Acompanhe seu progresso em cada matéria</h2>
       </header>
 
-      {loading && <p>Carregando...</p>}
+      {loading && (
+        <p className="text-sm text-slate-500 py-4">Carregando suas trilhas de aprendizado...</p>
+      )}
 
-      {error && (
+      {!loading && error && (
         <div className="mb-6 rounded-xl border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
           {error}
         </div>
@@ -118,96 +140,123 @@ const StudentTrailsPage = () => {
 
       {!loading && (
         <section className="mt-4 grid grid-cols-1 gap-6">
-          {categories.map((category) => {
-            const lp = learningPaths.find((lp) => lp.category.id === category.id)
+          {subjects.map((subjectName) => {
+            const category = categories.find((c) => c.name === subjectName) ?? null
+
+            const lp =
+              learningPaths.find(
+                (item) =>
+                  (category && item.categoryId === category.id) ||
+                  (category && item.category?.id === category.id) ||
+                  item.category?.name === subjectName
+              ) ?? null
+
+            const categoryCompleted =
+              lp?.contents?.filter((c) => c.status === 'completed').length ?? 0
+            const categoryTotal = lp?.contents?.length ?? 0
+
             return (
               <div
-                key={category.id}
+                key={subjectName}
                 className="group rounded-2xl border border-slate-200 bg-white p-5 shadow-sm shadow-slate-100"
               >
-                <div className="grid grid-cols-2 items-start justify-between">
-                  <h2 className="text-lg font-bold text-slate-900">
-                    {lp ? lp.category.name : category.name}
-                  </h2>
-
-                  <div className="flex flex-col items-end">
-                    <button
-                      type="button"
-                      className="text-sm mb-1 bg-blue-600 hover:bg-blue-700 font-medium text-white leading-5 py-2.5 px-4 rounded-full w-20"
-                      disabled
-                    >
-                      Nível
-                    </button>
+                <div className="flex items-start justify-between mb-3">
+                  <div>
+                    <h2 className="text-lg font-bold text-slate-900 flex items-center gap-2">
+                      <BookOpen size={18} className="text-slate-600" />
+                      {lp ? lp.category.name : subjectName}
+                    </h2>
+                    <p className="text-xs text-slate-500 mt-1">
+                      {lp
+                        ? `Trilha de ${lp.category.name} • ${lp.grade}º Ano`
+                        : 'Nenhuma trilha disponível'}
+                    </p>
                   </div>
+
+                  <button
+                    type="button"
+                    className="text-xs bg-blue-600 hover:bg-blue-700 font-semibold text-white leading-5 py-1.5 px-4 rounded-full"
+                    disabled
+                  >
+                    Nível 1
+                  </button>
                 </div>
 
-                <div className="flex justify-between mb-4 items-center">
-                  <p className="text-sm text-slate-500">
-                    {lp?.description ?? 'Nenhuma trilha disponível para esta categoria.'}
-                  </p>
-                  {lp && (
-                    <p className="text-xs text-slate-500 whitespace-nowrap">
-                      {lp.contents?.filter((c) => c.status === 'completed').length ?? 0}/
-                      {lp.contents?.length ?? 0} concluídos
-                    </p>
-                  )}
+                <div className="flex justify-between items-center mb-3">
+                  <div className="h-1 w-full bg-emerald-100 rounded-full overflow-hidden mr-4">
+                    <div
+                      className="h-full bg-emerald-500 transition-all duration-700"
+                      style={{
+                        width:
+                          categoryTotal > 0
+                            ? `${Math.round((categoryCompleted / categoryTotal) * 100)}%`
+                            : '0%',
+                      }}
+                    />
+                  </div>
+                  <span className="text-[10px] font-semibold text-slate-500 whitespace-nowrap">
+                    {categoryCompleted}/{categoryTotal} concluídos
+                  </span>
                 </div>
 
                 <div className="grid grid-cols-1 gap-3">
-                  {lp?.contents?.length
-                    ? lp.contents.map((content) => (
-                        <div
-                          key={content.id}
-                          className={`rounded-lg border border-slate-200 px-4 py-4 shadow-sm flex items-center justify-between
-                          ${
-                            content.status === 'blocked'
-                              ? 'bg-blue-50 cursor-not-allowed grayscale opacity-60'
-                              : 'bg-blue-50 hover:bg-blue-100'
-                          }`}
-                        >
-                          <div className="flex items-center gap-4">
-                            <span className="flex items-center justify-center w-10 h-10 text-sm font-semibold border border-blue-300 rounded-full bg-white">
-                              {content.orderNumber}
-                            </span>
+                  {lp?.contents?.length ? (
+                    lp.contents.map((content) => (
+                      <div
+                        key={content.contentId}
+                        className={`rounded-lg border border-slate-200 px-4 py-4 shadow-sm flex items-center justify-between ${
+                          content.status === 'blocked'
+                            ? 'bg-blue-50 cursor-not-allowed grayscale opacity-60'
+                            : 'bg-blue-50 hover:bg-blue-100'
+                        }`}
+                      >
+                        <div className="flex items-center gap-4">
+                          <span className="flex items-center justify-center w-10 h-10 text-sm font-semibold border border-blue-300 rounded-full bg-white">
+                            {content.orderNumber}
+                          </span>
 
-                            <div className="flex flex-col">
-                              <p className="font-medium text-slate-800">{content.title}</p>
+                          <div className="flex flex-col">
+                            <p className="font-medium text-slate-800">{content.title}</p>
 
-                              <div className="flex items-center gap-2 mt-1">
-                                <span className="text-xs font-medium px-2 py-1 rounded bg-gray-100 text-gray-700 border border-gray-200">
-                                  Nível {content.level}
-                                </span>
+                            <div className="flex items-center gap-2 mt-1">
+                              <span className="text-xs font-medium px-2 py-1 rounded bg-gray-100 text-gray-700 border border-gray-200">
+                                Nível {content.level}
+                              </span>
 
-                                <div
-                                  className={`flex items-center gap-1 text-xs font-medium px-2 py-1 rounded border ${getStatusStyle(
-                                    content.status
-                                  )}`}
-                                >
-                                  {content.status === 'completed' && <CheckCircle size={14} />}
-                                  {content.status === 'available' && <Play size={14} />}
-                                  {content.status === 'blocked' && <Lock size={14} />}
-                                  <span>{getStatusName(content.status)}</span>
-                                </div>
+                              <div
+                                className={`flex items-center gap-1 text-xs font-medium px-2 py-1 rounded border ${getStatusStyle(
+                                  content.status
+                                )}`}
+                              >
+                                {content.status === 'completed' && <CheckCircle size={14} />}
+                                {content.status === 'available' && <Play size={14} />}
+                                {content.status === 'blocked' && <Lock size={14} />}
+                                <span>{getStatusName(content.status)}</span>
                               </div>
                             </div>
                           </div>
+                        </div>
 
-                          {content.status !== 'blocked' && (
-                            <button
-                              type="button"
-                              className="text-sm font-medium py-2 px-5 rounded-md bg-blue-600 hover:bg-blue-700 text-white transition"
-                              onClick={() => navigate(`/content/${content.id}`)}
-                            >
-                              Estudar
-                            </button>
-                          )}
-                        </div>
-                      ))
-                    : !lp && (
-                        <div className="text-sm text-gray-500 py-2 text-center">
-                          Nenhum conteúdo nesta categoria
-                        </div>
-                      )}
+                        {content.status !== 'blocked' && (
+                          <button
+                            type="button"
+                            className="text-sm font-medium py-2 px-5 rounded-md bg-blue-600 hover:bg-blue-700 text-white transition"
+                            onClick={() =>
+                              navigate(
+                                Routes.CONTENT_DETAILS.replace(':id', content.contentId.toString())
+                              )
+                            }
+                          >
+                            Estudar
+                          </button>
+                        )}
+                      </div>
+                    ))
+                  ) : (
+                    <div className="text-sm text-slate-400 py-4 text-center">
+                      Nenhum conteúdo na trilha ainda
+                    </div>
+                  )}
                 </div>
               </div>
             )

--- a/src/pages/student-trails.tsx
+++ b/src/pages/student-trails.tsx
@@ -1,0 +1,221 @@
+import { Play, CheckCircle, Lock } from '@phosphor-icons/react'
+import { useEffect, useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+
+import { useAuth } from '@/hooks/useAuth'
+import { getForStudent, LearningPath } from '@/resources/learningPathResources'
+import { Routes } from '@/router/constants/routesMap'
+
+interface Category {
+  id: string
+  name: string
+}
+
+const StudentTrailsPage = () => {
+  const navigate = useNavigate()
+  const { isLoggedIn, me } = useAuth()
+
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const [learningPaths, setLearningPaths] = useState<LearningPath[]>([])
+
+  const categories: Category[] = [
+    { name: 'Português', id: '5677af84-cccc-476f-ab5e-e4789e18ee85' },
+    { name: 'Matemática', id: '8db6ca2e-0da4-4ac4-ba2e-0adfb7f01275' },
+    { name: 'Ciências', id: '7f2a1f19-d1aa-4bad-89e5-fc7d22c66bf2' },
+    { name: 'História', id: '46c7096e-8c05-4d2a-8cb2-2fa6ff88f187' },
+    { name: 'Geografia', id: 'c32e3cf1-32aa-4830-9662-3c3718d5a251' },
+  ]
+
+  useEffect(() => {
+    if (!isLoggedIn) {
+      navigate(Routes.SIGN_IN)
+      return
+    }
+
+    if (me && me.role !== 'student') {
+      navigate(Routes.HOME)
+      return
+    }
+
+    if (me?.sub) {
+      fetchLearningPaths(categories)
+    }
+  }, [isLoggedIn, me])
+
+  const fetchLearningPaths = async (categories: { id: string; name: string }[]) => {
+    setLoading(true)
+    setError(null)
+
+    try {
+      const allLearningPaths: LearningPath[] = []
+
+      for (const category of categories) {
+        try {
+          const response = await getForStudent(category.id)
+
+          const paths: LearningPath[] = response.data ? [response.data] : []
+          allLearningPaths.push(...paths)
+        } catch (err) {
+          console.error(`Erro ao carregar trilhas da categoria ${category.name}`, err)
+        }
+      }
+
+      const uniquePaths = Array.from(
+        new Map(allLearningPaths.map((item) => [item.id, item])).values()
+      )
+      setLearningPaths(uniquePaths)
+    } catch (err) {
+      setError('Não foi possível carregar suas trilhas de aprendizado.' + err)
+      setLearningPaths([])
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  const getStatusStyle = (status: string) => {
+    switch (status) {
+      case 'completed':
+        return 'bg-green-100 border-green-300 text-green-700'
+      case 'available':
+        return 'bg-blue-100 border-blue-300 text-blue-700'
+      case 'blocked':
+        return 'bg-slate-100 border-slate-300 text-slate-700'
+      default:
+        return ''
+    }
+  }
+
+  const getStatusName = (status: string) => {
+    switch (status) {
+      case 'available':
+        return 'Disponível'
+      case 'completed':
+        return 'Concluído'
+      case 'blocked':
+        return 'Bloqueado'
+      default:
+        return status
+    }
+  }
+
+  if (!isLoggedIn) return null
+
+  return (
+    <main className="p-10 w-full bg-gray-50 min-h-screen">
+      <header className="mb-8">
+        <h1 className="text-3xl font-bold text-slate-900">Minhas Trilhas</h1>
+        <h2 className="text-slate-500">Acompanhe seu progresso em cada matéria</h2>
+      </header>
+
+      {loading && <p>Carregando...</p>}
+
+      {error && (
+        <div className="mb-6 rounded-xl border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
+          {error}
+        </div>
+      )}
+
+      {!loading && (
+        <section className="mt-4 grid grid-cols-1 gap-6">
+          {categories.map((category) => {
+            const lp = learningPaths.find((lp) => lp.category.id === category.id)
+            return (
+              <div
+                key={category.id}
+                className="group rounded-2xl border border-slate-200 bg-white p-5 shadow-sm shadow-slate-100"
+              >
+                <div className="grid grid-cols-2 items-start justify-between">
+                  <h2 className="text-lg font-bold text-slate-900">
+                    {lp ? lp.category.name : category.name}
+                  </h2>
+
+                  <div className="flex flex-col items-end">
+                    <button
+                      type="button"
+                      className="text-sm mb-1 bg-blue-600 hover:bg-blue-700 font-medium text-white leading-5 py-2.5 px-4 rounded-full w-20"
+                      disabled
+                    >
+                      Nível
+                    </button>
+                  </div>
+                </div>
+
+                <div className="flex justify-between mb-4 items-center">
+                  <p className="text-sm text-slate-500">
+                    {lp?.description ?? 'Nenhuma trilha disponível para esta categoria.'}
+                  </p>
+                  {lp && (
+                    <p className="text-xs text-slate-500 whitespace-nowrap">
+                      {lp.contents?.filter((c) => c.status === 'completed').length ?? 0}/
+                      {lp.contents?.length ?? 0} concluídos
+                    </p>
+                  )}
+                </div>
+
+                <div className="grid grid-cols-1 gap-3">
+                  {lp?.contents?.length
+                    ? lp.contents.map((content) => (
+                        <div
+                          key={content.id}
+                          className={`rounded-lg border border-slate-200 px-4 py-4 shadow-sm flex items-center justify-between
+                          ${
+                            content.status === 'blocked'
+                              ? 'bg-blue-50 cursor-not-allowed grayscale opacity-60'
+                              : 'bg-blue-50 hover:bg-blue-100'
+                          }`}
+                        >
+                          <div className="flex items-center gap-4">
+                            <span className="flex items-center justify-center w-10 h-10 text-sm font-semibold border border-blue-300 rounded-full bg-white">
+                              {content.orderNumber}
+                            </span>
+
+                            <div className="flex flex-col">
+                              <p className="font-medium text-slate-800">{content.title}</p>
+
+                              <div className="flex items-center gap-2 mt-1">
+                                <span className="text-xs font-medium px-2 py-1 rounded bg-gray-100 text-gray-700 border border-gray-200">
+                                  Nível {content.level}
+                                </span>
+
+                                <div
+                                  className={`flex items-center gap-1 text-xs font-medium px-2 py-1 rounded border ${getStatusStyle(
+                                    content.status
+                                  )}`}
+                                >
+                                  {content.status === 'completed' && <CheckCircle size={14} />}
+                                  {content.status === 'available' && <Play size={14} />}
+                                  {content.status === 'blocked' && <Lock size={14} />}
+                                  <span>{getStatusName(content.status)}</span>
+                                </div>
+                              </div>
+                            </div>
+                          </div>
+
+                          {content.status !== 'blocked' && (
+                            <button
+                              type="button"
+                              className="text-sm font-medium py-2 px-5 rounded-md bg-blue-600 hover:bg-blue-700 text-white transition"
+                              onClick={() => navigate(`/content/${content.id}`)}
+                            >
+                              Estudar
+                            </button>
+                          )}
+                        </div>
+                      ))
+                    : !lp && (
+                        <div className="text-sm text-gray-500 py-2 text-center">
+                          Nenhum conteúdo nesta categoria
+                        </div>
+                      )}
+                </div>
+              </div>
+            )
+          })}
+        </section>
+      )}
+    </main>
+  )
+}
+
+export default StudentTrailsPage

--- a/src/resources/learningPathResources.ts
+++ b/src/resources/learningPathResources.ts
@@ -1,30 +1,36 @@
 import { get } from '@/lib/axios'
 
+export interface LearningPathCategory {
+  id: string
+  name: string
+}
+
+export type LearningPathContentStatus = 'completed' | 'available' | 'blocked'
+
+export interface LearningPathContent {
+  id?: string
+  contentId: string
+  orderNumber: number
+  title: string
+  level: string
+  status: LearningPathContentStatus
+}
+
 export interface LearningPath {
   id: string
   name: string
   categoryId: string
-  category: string
+  category: LearningPathCategory
   grade: string
   description?: string
-  content?: LearningPathContent[]
-}
-
-export interface LearningPathContent {
-  id: string
-  contentId: string
-  orderNumber: string
-  title: string
-  level: string
-  status: string
+  contents?: LearningPathContent[]
 }
 
 const learningPathBase = '/learning-paths/for-student'
 
+type LearningPathApiResponse = LearningPath | LearningPath[] | { learningPaths: LearningPath[] }
+
 export const getForStudent = (categoryId: string) =>
-  get<LearningPath[] | { learningPaths: LearningPath[] }>(
-    `${learningPathBase}?categoryId=${categoryId}`,
-    true
-  ).then((response) => {
-    return response
-  })
+  get<LearningPathApiResponse>(`${learningPathBase}?categoryId=${categoryId}`, true).then(
+    (response) => response
+  )

--- a/src/resources/learningPathResources.ts
+++ b/src/resources/learningPathResources.ts
@@ -1,0 +1,30 @@
+import { get } from '@/lib/axios'
+
+export interface LearningPath {
+  id: string
+  name: string
+  categoryId: string
+  category: string
+  grade: string
+  description?: string
+  content?: LearningPathContent[]
+}
+
+export interface LearningPathContent {
+  id: string
+  contentId: string
+  orderNumber: string
+  title: string
+  level: string
+  status: string
+}
+
+const learningPathBase = '/learning-paths/for-student'
+
+export const getForStudent = (categoryId: string) =>
+  get<LearningPath[] | { learningPaths: LearningPath[] }>(
+    `${learningPathBase}?categoryId=${categoryId}`,
+    true
+  ).then((response) => {
+    return response
+  })

--- a/src/router/client.tsx
+++ b/src/router/client.tsx
@@ -19,7 +19,6 @@ import DashboardStudentPage from '@/pages/dashboard-student'
 import NotFound from '@/pages/not-found'
 import QuestionPage from '@/pages/question'
 import RecommendationsPage from '@/pages/recommendations'
-import HomePage from '@/pages/HomePage'
 import SignInPage from '@/pages/sign-in'
 import ProfilePage from '@/pages/ProfilePage'
 import StudentTrailsPage from '@/pages/student-trails'
@@ -37,7 +36,8 @@ const router = createBrowserRouter([
     element: <BaseLayout />,
     children: [
       { index: true, element: <HomeRedirect /> },
-      { path: RoutePaths.HOME.replace('/', ''), element: <HomePage /> },
+      // Home deve levar para o dashboard correspondente ao perfil (aluno / professor)
+      { path: RoutePaths.HOME.replace('/', ''), element: <HomeRedirect /> },
       { path: RoutePaths.NOT_FOUND, element: <NotFound /> },
       {
         element: <PrivateRoutes />,

--- a/src/router/client.tsx
+++ b/src/router/client.tsx
@@ -15,6 +15,7 @@ import RecommendationsPage from '@/pages/recommendations'
 import HomePage from '@/pages/homePage'
 import SignInPage from '@/pages/sign-in'
 import ProfilePage from '@/pages/profilePage'
+import StudentTrailsPage from '@/pages/student-trails'
 
 const router = createBrowserRouter([
   {
@@ -46,6 +47,10 @@ const router = createBrowserRouter([
           {
             path: RoutePaths.PERFIL.replace('/', ''),
             element: <ProfilePage />,
+          },
+          {
+            path: RoutePaths.STUDENT_TRIALS.replace('/', ''),
+            element: <StudentTrailsPage />,
           },
         ],
       },

--- a/src/router/constants/routesMap.ts
+++ b/src/router/constants/routesMap.ts
@@ -14,6 +14,7 @@ const Routes = {
   QUESTION: '/avaliacoes/estudante/:id',
 
   RECOMMENDATIONS: '/recomendacoes',
+  MINHASTRILHAS: '/minhas-trilhas',
 
   NOT_FOUND: '*',
 } as const

--- a/src/router/routes.ts
+++ b/src/router/routes.ts
@@ -7,6 +7,5 @@ export default [
     index('../pages/homePage.tsx'),
     route(Routes.HOME.replace('/', ''), '../pages/homePage.tsx'),
   ]),
-
   layout('../layout/auth.tsx', [route(Routes.SIGN_IN.replace('/', ''), '../pages/sign-in.tsx')]),
 ] satisfies RouteConfig

--- a/src/services/contentService.ts
+++ b/src/services/contentService.ts
@@ -243,11 +243,20 @@ export const contentService = {
 
   /**
    * Categorias/matérias – para filtros e select no formulário.
-   * GET /categories (se o backend expuser). Caso contrário use getTeacherSubjects para professor.
+   * GET /categories – backend pode responder:
+   * - [ { id, name } ]
+   * - { categories: [ { id, name } ] }
    */
   getCategories: async () => {
-    const response = await get<CategoryDto[]>('/categories', true)
-    return Array.isArray(response.data) ? response.data : []
+    const response = await get<CategoryDto[] | { categories: CategoryDto[] }>('/categories', true)
+    const data = response.data
+
+    if (Array.isArray(data)) return data
+    if (data && Array.isArray((data as { categories?: CategoryDto[] }).categories)) {
+      return (data as { categories: CategoryDto[] }).categories
+    }
+
+    return []
   },
 
   /**


### PR DESCRIPTION
## 🚀 Descrição

Com base na task "Story F.4.2 — Tela aluno: ver trilha por matéria com indicadores (concluído, disponível, bloqueado, recomendado)", criei uma tela para a rota "/minhas-trilhas". É possível visualizarmos nesta todas as categorias/matérias possíveis (de forma estática pois não temos uma API que busque as categorias existentes), suas trilhas _default_ e os conteúdos existentes nesta. Ao clicar em "Estudar", seremos redirecionados para a aba do conteúdo. Somente os conteúdos completos ou disponíveis podem ser acessados; os bloqueados não serão clicáveis.

Somente está sendo exibida a trilha _default_ pois a rota acessível pelo estudante somente traz esta de acordo com a categoria, assim como todos seus conteúdos.

## 📝 Tipo de mudança

- [ ] Bugfix
- [X] Nova feature
- [ ] Refatoração
- [ ] Documentação
- [ ] Testes
- [ ] Outro (descreva):

## 📸 Prints (se aplicável)

<img width="1912" height="871" alt="image" src="https://github.com/user-attachments/assets/a89bfad4-7590-465b-84a0-691154cec009" />

## 🧪 Como testar

Para testar, basta entrar com um perfil de usuário e clicar na opção "Minhas trilhas" no menu.

## ✅ Checklist

- [ ] Adicionei/atualizei testes relacionados
- [ ] Atualizei a documentação (README, Wiki, etc)
- [ ] Adicionei/atualizei o changelog
- [X] O código segue o padrão do projeto (lint, prettier)
- [X] O PR está pronto para revisão

## 📚 Referências

<!-- Links para issues, cards, RFCs, ou documentação relevante. -->

## 🤝 Quem deve revisar

@JJPontes @Glomes @guimatos7 @dfsilvadev 
